### PR TITLE
link to the source code

### DIFF
--- a/Paste.toml.template
+++ b/Paste.toml.template
@@ -12,6 +12,8 @@ ident = "Rocket"                     # server `Ident` header
 ip_header = "X-Real-IP"              # header to inspect for client IP
 log_level = "normal"                 # console log level
 cli_colors = true                    # enable (detect TTY) or disable CLI colors
+# If you modify the code on your running instance, you are legally obligated to update this
+source_code_url = "https://github.com/SergioBenitez/rktpb"
 
 [default.cors] # CORS config - one key/value for each allowed host
 "https://example.com" = ["options", "get", "post", "delete"] # methods to allow

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ The complete list of configurable parameters is below:
 | `shutdown.signals` | `["term", "hup"]`           | signals that initiate a shutdown          |
 | `shutdown.grace`   | `5`                         | grace period length in seconds            |
 | `shutdown.mercy`   | `5`                         | mercy period length in seconds            |
+|                    |                             |                                           |
+| `source_code_url`  | (this repo)                 | a link to your instance's source code     |
 
 You'll definitely want to configure the values in the first two categories, from
 `id_length` to `cors`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,7 @@ pub struct Config {
     #[serde(deserialize_with = "directory")]
     #[serde(serialize_with = "RelativePathBuf::serialize_original")]
     pub upload_dir: RelativePathBuf,
+    pub source_code_url: String,
 }
 
 impl Config {
@@ -51,6 +52,7 @@ impl Config {
                 paste_limit: 384.kibibytes(),
                 server_url: default_server_url,
                 upload_dir: "upload".into(),
+                source_code_url: String::from("https://github.com/SergioBenitez/rktpb"),
             }));
 
         // Configure Rocket based on `Config` settings. If this fails now, it's

--- a/templates/index.html.tera
+++ b/templates/index.html.tera
@@ -98,5 +98,7 @@
               curl --data-binary @${file} {{ config.server_url }}
           }
       {%- endif %}
+
+       Source code: <a href="{{ config.source_code_url }}">{{ config.source_code_url }}</a>
   </pre></body>
 </html>

--- a/templates/index.html.tera
+++ b/templates/index.html.tera
@@ -99,6 +99,8 @@
           }
       {%- endif %}
 
-       Source code: <a href="{{ config.source_code_url }}">{{ config.source_code_url }}</a>
+  SOURCE CODE
+
+      <a href="{{ config.source_code_url }}">{{ config.source_code_url }}</a>
   </pre></body>
 </html>


### PR DESCRIPTION
Hi there,

I was looking for a dead simple pastebin to self-host but it took me a while to find the source code for paste.rs because there's no link to it on the homepage. Despite being a nice thing to do, you are required to link to your source code on the website because you have more than one contributor and their contributions are AGPLv3 licensed. Furthermore, people that fork your code must be able to link to their own fork.

I made a link in the index template and made it configurable so that forks can comply with the AGPLv3. I also considered making it hardcoded, because if one is forking the repo they can also make a change to the hardcoded link in the template. But I figure this is the better approach.

My only concern is that I had to specify the link twice. Dunno if it's worth it to not do that, especially given that all the other config settings have defaults in the Paste.toml.template *and* the code.